### PR TITLE
Cleanup: 

### DIFF
--- a/src/rviz/robot/robot_link.cpp
+++ b/src/rviz/robot/robot_link.cpp
@@ -164,7 +164,6 @@ RobotLink::RobotLink(Robot* robot,
   , trail_(nullptr)
   , axes_(nullptr)
   , material_alpha_(1.0)
-  , use_original_material(true)
   , robot_alpha_(1.0)
   , only_render_depth_(false)
   , is_selectable_(true)
@@ -384,34 +383,35 @@ void RobotLink::setOnlyRenderDepth(bool onlyRenderDepth)
 void RobotLink::updateAlpha()
 {
   float link_alpha = alpha_property_->getFloat();
-  M_SubEntityToMaterial::iterator it = materials_.begin();
-  M_SubEntityToMaterial::iterator end = materials_.end();
-  for (; it != end; ++it)
+  for (auto& item : materials_)
   {
-    const Ogre::MaterialPtr& material = it->second;
+    Ogre::MaterialPtr& active = item.second.first;
+    const Ogre::MaterialPtr& original = item.second.second;
 
     if (only_render_depth_)
     {
-      material->setColourWriteEnabled(false);
-      material->setDepthWriteEnabled(true);
+      active->setColourWriteEnabled(false);
+      active->setDepthWriteEnabled(true);
     }
     else
     {
-      Ogre::ColourValue color = material->getTechnique(0)->getPass(0)->getDiffuse();
+      Ogre::ColourValue color = active->getTechnique(0)->getPass(0)->getDiffuse();
       color.a = robot_alpha_ * material_alpha_ * link_alpha;
-      material->setDiffuse(color);
+      active->setDiffuse(color);
 
-      if (color.a < 0.9998)
+      if (color.a < 0.9998) // transparent
       {
-        material->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
-        material->setDepthWriteEnabled(false);
-        use_original_material = false;
+        active->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+        active->setDepthWriteEnabled(false);
       }
-      else
+      else if (active == original)
       {
-        material->setSceneBlending(Ogre::SBT_REPLACE);
-        material->setDepthWriteEnabled(true);
-        use_original_material = true;
+        active->setSceneBlending(Ogre::SBT_REPLACE);
+        active->setDepthWriteEnabled(true);
+      }
+      else // restore original material
+      {
+        original->copyDetailsTo(active);
       }
     }
   }
@@ -658,20 +658,23 @@ void RobotLink::createEntityForGeometryElement(const urdf::LinkConstSharedPtr& l
       Ogre::SubEntity* sub = entity->getSubEntity(i);
       const std::string& material_name = sub->getMaterialName();
 
+      Ogre::MaterialPtr active, original;
       if (material_name == "BaseWhite" || material_name == "BaseWhiteNoLighting")
       {
-        sub->setMaterial(default_material_);
+        sub->setMaterial(active = default_material_);
+        original = active; // we don't need a backup copy of the default material
       }
       else
       {
-        // create a new material copy for each instance of a RobotLink
-        Ogre::MaterialPtr mat = Ogre::MaterialPtr(new Ogre::Material(
+        // create a new material copy for each instance of a RobotLink to allow modification per link
+        active = Ogre::MaterialPtr(new Ogre::Material(
             nullptr, material_name, 0, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME));
-        *mat = *sub->getMaterial();
-        sub->setMaterial(mat);
+        *active = *sub->getMaterial();
+        sub->setMaterial(active);
+        // create a backup of the material as we will modify the active one e.g. in updateAlpha()
+        original = active->clone(sub->getMaterial()->getName() + "_original");
       }
-      materials_[sub] = sub->getMaterial();
-      original_materials_[sub] = sub->getMaterial()->clone(sub->getMaterial()->getName() + "_original");
+      materials_[sub] = std::make_pair(active, original);
     }
   }
 }
@@ -927,12 +930,9 @@ void RobotLink::setToNormalMaterial()
   }
   else
   {
-    M_SubEntityToMaterial::iterator it = materials_.begin();
-    M_SubEntityToMaterial::iterator end = materials_.end();
-    M_SubEntityToMaterial::iterator it_original = original_materials_.begin();
-    for (; it != end; ++it, ++it_original)
+    for (const auto& item : materials_)
     {
-      it->first->setMaterial(use_original_material ? it_original->second : it->second);
+      item.first->setMaterial(item.second.first);
     }
   }
 }

--- a/src/rviz/robot/robot_link.h
+++ b/src/rviz/robot/robot_link.h
@@ -214,12 +214,12 @@ protected:
   FloatProperty* alpha_property_;
 
 private:
-  typedef std::map<Ogre::SubEntity*, Ogre::MaterialPtr> M_SubEntityToMaterial;
+  // maintain the original material of each SubEntity to restore it after unsetColor()
+  using M_SubEntityToMaterial =
+      std::map<Ogre::SubEntity*, std::pair<Ogre::MaterialPtr, Ogre::MaterialPtr>>;
   M_SubEntityToMaterial materials_;
-  M_SubEntityToMaterial original_materials_;
   Ogre::MaterialPtr default_material_;
   std::string default_material_name_;
-  bool use_original_material;
 
   std::vector<Ogre::Entity*>
       visual_meshes_; ///< The entities representing the visual mesh of this link (if they exist)


### PR DESCRIPTION
- Avoid evaluating use_original_material condition in each update()
- Combine active and backup material into a pair with `materials_`. This avoids looping over both maps in sync, which is brittle.